### PR TITLE
Fix two typing mistakes in glas.internal

### DIFF
--- a/source/glas/internal/l1_.d
+++ b/source/glas/internal/l1_.d
@@ -590,7 +590,7 @@ q{
     }
 
     static if (isComplex!T)
-    void glas_} ~ prefix!Type ~ prefix!(realType!Type) ~ q{scal(
+    void glas_} ~ prefix!Type ~ prefix!(realType!Type) ~ "I" ~ q{scal(
         I a,
         Slice!(SliceKind.universal, [1], T*) xsl,
         )

--- a/source/glas/internal/utility.d
+++ b/source/glas/internal/utility.d
@@ -31,7 +31,7 @@ template realType(C)
         alias realType = typeof(Unqual!C.init.re);
     else
     static if (isImaginary!C)
-        alias realType = typeof(Uqual!C.init.im);
+        alias realType = typeof(Unqual!C.init.im);
     else
         alias realType = Unqual!C;
 }


### PR DESCRIPTION
In glas.internal.l1_ the imaginary variant of glas_\*\*Iscal was missing the 'I', creating a conflict with the real version during compilation. I also noticed that the realType template had a small error. This PR fixes these two errors.